### PR TITLE
Revert "Update config.yml"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,20 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/reference/configuration-reference
 version: 2.1
 
 # Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/guides/orchestrate/jobs-steps/#jobs-overview & https://circleci.com/docs/reference/configuration-reference/#jobs
 jobs:
-  build:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/guides/execution-managed/executor-intro/ & https://circleci.com/docs/reference/configuration-reference/#executor-job
     docker:
-      - image: cimg/azure:2025.01
-    steps:
-      - checkout
-      - run: az --version
+      # Specify the version you desire here
+      # See: https://circleci.com/developer/images/image/cimg/base
+      - image: cimg/base:current
 
     # Add steps to the job
+    # See: https://circleci.com/docs/guides/orchestrate/jobs-steps/#steps-overview & https://circleci.com/docs/reference/configuration-reference/#steps
     steps:
       # Checkout the code as the first step.
       - checkout
@@ -18,6 +23,7 @@ jobs:
           command: "echo Hello, World!"
 
 # Orchestrate jobs using workflows
+# See: https://circleci.com/docs/guides/orchestrate/workflows/ & https://circleci.com/docs/reference/configuration-reference/#workflows
 workflows:
   say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run.


### PR DESCRIPTION
Reverts Dargon789/terminal#4

## Summary by Sourcery

Restore the basic CircleCI example workflow that runs a simple "say-hello" job using the generic cimg/base image instead of the previous Azure-specific build job.

Build:
- Revert the previous CircleCI configuration that used an Azure image and reinstate a simple say-hello job based on CircleCI's standard example.

CI:
- Simplify the CircleCI pipeline to a single say-hello job and workflow using the cimg/base:current Docker image and add reference comments to CircleCI docs.